### PR TITLE
Tratamento para propriedade ExpiresIn

### DIFF
--- a/src/Nuuvify.CommonPack.Security.Abstraction/Results/CredentialToken.cs
+++ b/src/Nuuvify.CommonPack.Security.Abstraction/Results/CredentialToken.cs
@@ -52,6 +52,9 @@ namespace Nuuvify.CommonPack.Security.Abstraction
 
         private long _expiresIn;
 
+        /// <summary>
+        /// Valor deve ser diferente de 0 para que Expires seja calculado
+        /// </summary>
         public long ExpiresIn
         {
             get
@@ -61,7 +64,8 @@ namespace Nuuvify.CommonPack.Security.Abstraction
             set
             {
                 _expiresIn = value;
-                Expires = DateTimeOffset.Now.AddSeconds(_expiresIn);
+                if (_expiresIn != 0)
+                    Expires = DateTimeOffset.Now.AddSeconds(_expiresIn);
             }
         }
 


### PR DESCRIPTION
Essa alteração deve retornar os dados corretamente no IDistributedCache